### PR TITLE
Roy's third review

### DIFF
--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -101,7 +101,7 @@ contract ICO is Ownable {
         require(!saleClosed);
         require(initialTime <= now);
         require(whiteList[msg.sender].offeredWei > 0);
-        require(weiPaid <= weiCap - weiRaised);
+        require(weiPaid <= weiCap.sub(weiRaised));
         // can only purchase once every 24 hours
         require(now.sub(whiteList[msg.sender].lastPurchasedTimestamp) > 24 hours);
         uint256 elapsedTime = now.sub(initialTime);

--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -11,7 +11,6 @@ contract ICO is Ownable {
     using SafeMath for uint256;
 
     struct WhiteListRecord {
-        bool isInWhiteList;
         uint256 offeredWei;
         uint256 lastPurchasedTimestamp;
     }
@@ -75,7 +74,7 @@ contract ICO is Ownable {
     */
     function addToWhiteList(address[] addresses, uint256 weiPerContributor) public onlyOwner {
         for (uint32 i = 0; i < addresses.length; i++) {
-            whiteList[addresses[i]] = WhiteListRecord(true, weiPerContributor, 0);
+            whiteList[addresses[i]] = WhiteListRecord(weiPerContributor, 0);
         }
     }
 
@@ -102,7 +101,7 @@ contract ICO is Ownable {
     function validatePurchase(uint256 weiPaid) internal {
         require(!saleClosed);
         require(initialTime <= now);
-        require(whiteList[msg.sender].isInWhiteList);
+        require(whiteList[msg.sender].offeredWei > 0);
         require(weiPaid <= weiCap - weiRaised);
         // can only purchase once every 24 hours
         require(now.sub(whiteList[msg.sender].lastPurchasedTimestamp) > 24 hours);

--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -18,7 +18,7 @@ contract ICO is Ownable {
 
     OneledgerToken public token;
     address public wallet; // Address where funds are collected
-    uint256 public rate;     // How many token units a buyer gets per eth
+    uint256 public rate;   // How many token units a buyer gets per eth
     mapping(address => WhiteListRecord) private whiteList;
     uint256 private initialTime;
     bool private saleClosed;

--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -24,7 +24,7 @@ contract ICO is Ownable {
     uint256 public weiCap;
     uint256 public weiRaised;
 
-    uint256 public totalTokenSupply = 1000000000 * (10 ** 18);
+    uint256 public TOTAL_TOKEN_SUPPLY = 1000000000 * (10 ** 18);
 
     event BuyTokens(uint256 weiAmount, uint256 rate, uint256 token, address beneficiary);
 
@@ -34,7 +34,7 @@ contract ICO is Ownable {
     function ICO(address _wallet, uint256 _rate, uint256 _startDate, uint256 _weiCap) public {
         require(_rate > 0);
         require(_wallet != address(0));
-        require(_weiCap.mul(_rate) <= totalTokenSupply);
+        require(_weiCap.mul(_rate) <= TOTAL_TOKEN_SUPPLY);
 
         wallet = _wallet;
         rate = _rate;
@@ -92,7 +92,7 @@ contract ICO is Ownable {
      */
     function closeSale() public onlyOwner {
         saleClosed = true;
-        token.mint(owner, totalTokenSupply.sub(token.totalSupply()));
+        token.mint(owner, TOTAL_TOKEN_SUPPLY.sub(token.totalSupply()));
         token.finishMinting();
         token.transferOwnership(owner);
     }

--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -89,13 +89,12 @@ contract ICO is Ownable {
 
     /**
      * @dev close the ICO
-      param newOwner new owner of the token contract
      */
-    function closeSale(address newOwner) public onlyOwner {
+    function closeSale() public onlyOwner {
         saleClosed = true;
-        token.mint(newOwner, totalTokenSupply.sub(token.totalSupply()));
+        token.mint(owner, totalTokenSupply.sub(token.totalSupply()));
         token.finishMinting();
-        token.transferOwnership(newOwner);
+        token.transferOwnership(owner);
     }
 
     function validatePurchase(uint256 weiPaid) internal {

--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -18,9 +18,9 @@ contract ICO is Ownable {
     OneledgerToken public token;
     address public wallet; // Address where funds are collected
     uint256 public rate;   // How many token units a buyer gets per eth
-    mapping(address => WhiteListRecord) private whiteList;
-    uint256 private initialTime;
-    bool private saleClosed;
+    mapping (address => WhiteListRecord) public whiteList;
+    uint256 public initialTime;
+    bool public saleClosed;
     uint256 public weiCap;
     uint256 public weiRaised;
 

--- a/contracts/ICO.sol
+++ b/contracts/ICO.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.21;
+pragma solidity 0.4.23;
 
 import "./OneledgerToken.sol";
 import "./OneledgerTokenVesting.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.21;
+pragma solidity 0.4.23;
 
 contract Migrations {
   address public owner;

--- a/contracts/OneledgerToken.sol
+++ b/contracts/OneledgerToken.sol
@@ -19,7 +19,7 @@ contract OneledgerToken is MintableToken {
     /**
      * @dev restrict function to be callable when token is active
      */
-    modifier isActived() {
+    modifier activated() {
         require(active == true);
         _;
     }
@@ -40,16 +40,16 @@ contract OneledgerToken is MintableToken {
     }
 
     /**
-     * @dev transfer    ERC20 standard transfer wrapped with isActived
+     * @dev transfer    ERC20 standard transfer wrapped with `activated` modifier
      */
-    function transfer(address to, uint256 value) public isActived    returns (bool) {
+    function transfer(address to, uint256 value) public activated returns (bool) {
         return super.transfer(to, value);
     }
 
     /**
-     * @dev transfer    ERC20 standard transferFrom wrapped with isActived
+     * @dev transfer    ERC20 standard transferFrom wrapped with `activated` modifier
      */
-    function transferFrom(address from, address to, uint256 value) public isActived returns (bool) {
+    function transferFrom(address from, address to, uint256 value) public activated returns (bool) {
         return super.transferFrom(from, to, value);
     }
 }

--- a/contracts/OneledgerToken.sol
+++ b/contracts/OneledgerToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.21;
+pragma solidity 0.4.23;
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 import "zeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
@@ -20,7 +20,7 @@ contract OneledgerToken is MintableToken {
      * @dev restrict function to be callable when token is active
      */
     modifier isActived() {
-        require(active == true); 
+        require(active == true);
         _;
     }
 

--- a/contracts/OneledgerToken.sol
+++ b/contracts/OneledgerToken.sol
@@ -14,22 +14,13 @@ contract OneledgerToken is MintableToken {
     string public name = "Oneledger Token";
     string public symbol = "OLT";
     uint256 public decimals = 18;
-    bool public active;
-
+    bool public active = false;
     /**
      * @dev restrict function to be callable when token is active
      */
     modifier activated() {
         require(active == true);
         _;
-    }
-
-    /**
-     * @dev constructor
-     * param initial_supply not include decimals
-     */
-    function OneledgerToken() public {
-        active = false;
     }
 
     /**

--- a/contracts/OneledgerTokenVesting.sol
+++ b/contracts/OneledgerTokenVesting.sol
@@ -15,7 +15,7 @@ contract OneledgerTokenVesting is Ownable {
 
     uint256 public startFrom;
     uint256 public period;
-    uint256 public tokenReleasedPerPeriod;
+    uint256 public tokensReleasedPerPeriod;
 
     uint256 public elapsedPeriods;
 
@@ -24,13 +24,13 @@ contract OneledgerTokenVesting is Ownable {
      * @param _beneficiary address of the beneficiary to whom vested tokens are transferred
      * @param _startFrom Datetime when the vesting will begin
      * @param _period The preiod to release the token
-     * @param _tokenReleasedPerPeriod the token to release per period
+     * @param _tokensReleasedPerPeriod the token to release per period
      */
     function OneledgerTokenVesting(
         address _beneficiary,
         uint256 _startFrom,
         uint256 _period,
-        uint256 _tokenReleasedPerPeriod
+        uint256 _tokensReleasedPerPeriod
     ) public {
         require(_beneficiary != address(0));
         require(_startFrom >= now);
@@ -38,7 +38,7 @@ contract OneledgerTokenVesting is Ownable {
         beneficiary = _beneficiary;
         startFrom = _startFrom;
         period = _period;
-        tokenReleasedPerPeriod = _tokenReleasedPerPeriod;
+        tokensReleasedPerPeriod = _tokensReleasedPerPeriod;
         elapsedPeriods = 0;
     }
 
@@ -65,11 +65,11 @@ contract OneledgerTokenVesting is Ownable {
         uint256 elapsedTime = now.sub(startFrom);
         uint256 periodsInCurrentRelease = elapsedTime.div(period).sub(elapsedPeriods);
         uint256 availableBalance = token.balanceOf(this);
-        uint256 tokenReadyToRelease = periodsInCurrentRelease.mul(tokenReleasedPerPeriod);
-        if (tokenReadyToRelease >= availableBalance) {
+        uint256 tokensReadyToRelease = periodsInCurrentRelease.mul(tokensReleasedPerPeriod);
+        if (tokensReadyToRelease >= availableBalance) {
             return (availableBalance, periodsInCurrentRelease);
         } else {
-            return (tokenReadyToRelease, periodsInCurrentRelease);
+            return (tokensReadyToRelease, periodsInCurrentRelease);
         }
     }
 }

--- a/contracts/OneledgerTokenVesting.sol
+++ b/contracts/OneledgerTokenVesting.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.21;
+pragma solidity 0.4.23;
 
 import "./OneledgerToken.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/OneledgerTokenVesting.sol
+++ b/contracts/OneledgerTokenVesting.sol
@@ -48,28 +48,13 @@ contract OneledgerTokenVesting is Ownable {
      */
     function release(OneledgerToken token) public {
         require(token.balanceOf(this) >= 0 && now >= startFrom);
-        uint256 amountToTransfer;
-        uint256 periodsInCurrentRelease;
-        (amountToTransfer, periodsInCurrentRelease) = releasableAmount(token);
+        uint256 elapsedTime = now.sub(startFrom);
+        uint256 periodsInCurrentRelease = elapsedTime.div(period).sub(elapsedPeriods);
+        uint256 tokensReadyToRelease = periodsInCurrentRelease.mul(tokensReleasedPerPeriod);
+        uint256 amountToTransfer = tokensReadyToRelease > token.balanceOf(this) ? token.balanceOf(this) : tokensReadyToRelease;
         require(amountToTransfer > 0);
         elapsedPeriods = elapsedPeriods.add(periodsInCurrentRelease);
         token.transfer(beneficiary, amountToTransfer);
         emit Released(amountToTransfer);
-    }
-
-     /**
-      * @dev releasableAmount the amount that can be released
-      * param token Oneledger token which is being vested
-      */
-    function releasableAmount(OneledgerToken token) public view returns (uint256, uint256) {
-        uint256 elapsedTime = now.sub(startFrom);
-        uint256 periodsInCurrentRelease = elapsedTime.div(period).sub(elapsedPeriods);
-        uint256 availableBalance = token.balanceOf(this);
-        uint256 tokensReadyToRelease = periodsInCurrentRelease.mul(tokensReleasedPerPeriod);
-        if (tokensReadyToRelease >= availableBalance) {
-            return (availableBalance, periodsInCurrentRelease);
-        } else {
-            return (tokensReadyToRelease, periodsInCurrentRelease);
-        }
     }
 }

--- a/contracts/OneledgerTokenVesting.sol
+++ b/contracts/OneledgerTokenVesting.sol
@@ -8,7 +8,7 @@ import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 contract OneledgerTokenVesting is Ownable {
     using SafeMath for uint256;
 
-    event VestingReleased(uint256 amount);
+    event Released(uint256 amount);
 
     // beneficiary of tokens after they are released
     address public beneficiary;
@@ -54,7 +54,7 @@ contract OneledgerTokenVesting is Ownable {
         require(amountToTransfer > 0);
         elapsedPeriods = elapsedPeriods.add(periodsInCurrentRelease);
         token.transfer(beneficiary, amountToTransfer);
-        emit VestingReleased(amountToTransfer);
+        emit Released(amountToTransfer);
     }
 
      /**

--- a/contracts/OneledgerTokenVesting.sol
+++ b/contracts/OneledgerTokenVesting.sol
@@ -2,10 +2,8 @@ pragma solidity 0.4.23;
 
 import "./OneledgerToken.sol";
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
-
-contract OneledgerTokenVesting is Ownable {
+contract OneledgerTokenVesting {
     using SafeMath for uint256;
 
     event Released(uint256 amount);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3927,9 +3927,9 @@
       "dev": true
     },
     "solc": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.21.tgz",
-      "integrity": "sha512-8lJmimVjOG9AJOQRWS2ph4rSctPMsPGZ4H360HLs5iI+euUlt7iAvUxSLeFZZzwk0kas4Qta7HmlMXNU3yYwhw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
+      "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -4281,13 +4281,13 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.5.tgz",
-      "integrity": "sha512-6sOVFQ0xNbb52MMWf0nHxv0FiXWPTV+OIbq1B0+I5F3sIS8JJ7pM1+o7chbs+oO/CLqbbC6ggXJqFWzIWaiaQg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.8.tgz",
+      "integrity": "sha512-btDML3J9Ao+UDqR725ajTybcEqyXzxFzJDC/NAXOyOXoXf2HJwKq6VEvnjP9qc6owA+fJ50d87MmsPRXk+riCg==",
       "requires": {
         "mocha": "3.5.3",
         "original-require": "1.0.1",
-        "solc": "0.4.21"
+        "solc": "0.4.23"
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "compile": "truffle compile",
     "ganache": "ganache-cli -p 8546 -e 100000000000000000000 > /dev/null 2>&1 & echo $!",
     "test": "truffle test --network development",
+    "test-scenarios": "truffle test --network development scenarios/*",
     "test-ganache": "bash scripts/ganache_test.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^2.0.2",
     "ganache-cli": "6.1.0",
-    "truffle": "4.1.5",
+    "truffle": "4.1.8",
     "zeppelin-solidity": "1.8.0"
   },
   "devDependencies": {

--- a/scenarios/addTierTest.js
+++ b/scenarios/addTierTest.js
@@ -15,40 +15,45 @@ require('chai')
 
 
 contract('ICO contract -- whitelisting tiers', function([wallet, ...users]) {
+
   let ico;
+
   beforeEach(async ()=>{
-    let weiCap = 10000 * (10 ** 18);//covert eth to wei
-    let ratePerWei = 9668; //convert to rate per wei
-    ico = await ICO.new(wallet,ratePerWei,latestTime(), weiCap);
+    let weiCap = web3.toWei(10000); // covert eth to wei
+    let ratePerWei = 9668; // convert to rate per wei
+    ico = await ICO.new(wallet, ratePerWei, latestTime(), weiCap);
   });
+
   it("should allow to add tier 1 users", async () => {
     //simple fake address generator
     let addresses = []
-    for (let i =1; i <= 500 ; i++){
+    for (let i = 1; i <= 500; i++){
       addresses.push(`0x${("0000000000000000000000000000000000000000" + i).substr(-40)}`);
     }
-    for (let i=0; i< 5; i++){
-      await ico.addToWhiteList(addresses.slice(i * 100,i * 100 + 99), 1.36 * (10 ** 18)).should.be.fulfilled;
+    for (let i = 0; i < 5; i++){
+      await ico.addToWhiteList(addresses.slice(i * 100, i * 100 + 99), 1.36 * (10 ** 18)).should.be.fulfilled;
     }
   });
+
   it("should allow to add tier 2 users", async () => {
     //simple fake address generator
     let addresses = []
-    for (let i =1; i <= 2500 ; i++){
+    for (let i = 1; i <= 2500; i++){
       addresses.push(`0x${("0000000000000000000000000000000000000000" + i).substr(-40)}`);
     }
-    for (let i=0; i< 25; i++){
-      await ico.addToWhiteList(addresses.slice(i * 100,i * 100 + 99), 1.36 * (10 ** 18)).should.be.fulfilled;
+    for (let i=0; i < 25; i++){
+      await ico.addToWhiteList(addresses.slice(i * 100, i * 100 + 99), 1.36 * (10 ** 18)).should.be.fulfilled;
     }
   });
+
   it("should allow to add tier 3 users", async () => {
     //simple fake address generator
     let addresses = []
-    for (let i =1; i <= 7000 ; i++){
+    for (let i = 1; i <= 7000; i++){
       addresses.push(`0x${("0000000000000000000000000000000000000000" + i).substr(-40)}`);
     }
-    for (let i=0; i< 70; i++){
-      await ico.addToWhiteList(addresses.slice(i * 100,i * 100 + 99), 0.6 * (10 ** 18)).should.be.fulfilled;
+    for (let i = 0; i < 70; i++){
+      await ico.addToWhiteList(addresses.slice(i * 100, i * 100 + 99), 0.6 * (10 ** 18)).should.be.fulfilled;
     }
   })
 })

--- a/scenarios/addTierTest.js
+++ b/scenarios/addTierTest.js
@@ -14,7 +14,7 @@ require('chai')
   .should();
 
 
-contract('ICO contract', function([wallet, ...users]) {
+contract('ICO contract -- whitelisting tiers', function([wallet, ...users]) {
   let ico;
   beforeEach(async ()=>{
     let weiCap = 10000 * (10 ** 18);//covert eth to wei

--- a/scenarios/deployICOTest.js
+++ b/scenarios/deployICOTest.js
@@ -21,7 +21,7 @@ contract('ICO Contract -- deployment', function([owner, wallet]) {
   it("should be able to deployed success", async () => {
     let weiCap = web3.toWei(10000); // covert eth to wei
     let ratePerWei = 9668; // convert to rate per wei
-    await ICO.new(wallet,ratePerWei,latestTime(), weiCap).should.be.fulfilled;
+    await ICO.new(wallet, ratePerWei, latestTime(), weiCap).should.be.fulfilled;
   });
 
 })

--- a/scenarios/deployICOTest.js
+++ b/scenarios/deployICOTest.js
@@ -17,13 +17,11 @@ require('chai')
   .should();
 
 contract('ICO Contract -- deployment', function([owner, wallet]) {
-  let ico  = null;
-  beforeEach(async ()=>{
 
-  });
   it("should be able to deployed success", async () => {
-    let weiCap = 10000 * (10 ** 18);//covert eth to wei
-    let ratePerWei = 9668; //convert to rate per wei
+    let weiCap = web3.toWei(10000); // covert eth to wei
+    let ratePerWei = 9668; // convert to rate per wei
     await ICO.new(wallet,ratePerWei,latestTime(), weiCap).should.be.fulfilled;
-  })
+  });
+
 })

--- a/scenarios/deployICOTest.js
+++ b/scenarios/deployICOTest.js
@@ -16,7 +16,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
-contract('ICO Contract', function([owner, wallet]) {
+contract('ICO Contract -- deployment', function([owner, wallet]) {
   let ico  = null;
   beforeEach(async ()=>{
 

--- a/scenarios/icoPurchaseTest.js
+++ b/scenarios/icoPurchaseTest.js
@@ -143,8 +143,8 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
   it("should allow token to be able to transfer after close sale and token activate", async () => {
     await increaseTime(duration.days(11) + duration.minutes(1));
     await ico.sendTransaction({from: user, value: 2 * (10 ** 18)}).should.be.fulfilled;
-    await ico.closeSale(newOwner);
-    await token.activate({from: newOwner});
+    await ico.closeSale();
+    await token.activate();
     await token.transfer(userNotInWhiteList, 10 * (10 ** 18), {from: user}).should.be.fulfilled;
   })
 })

--- a/scenarios/icoPurchaseTest.js
+++ b/scenarios/icoPurchaseTest.js
@@ -10,12 +10,13 @@ require('chai')
 contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWhiteList, superRichUser, newOwner]) {
   let ico ;
   let token;
+
   beforeEach(async ()=>{
-    let weiCap = 10000 * (10 ** 18);//covert eth to wei
-    let ratePerWei = 9668; //convert to rate per wei
+    let weiCap = web3.toWei(10000);
+    let ratePerWei = 9668; // convert to rate per wei
     ico = await ICO.new(wallet,ratePerWei,latestTime()+duration.days(10), weiCap);
     token = OneledgerToken.at(await ico.token());
-    await ico.addToWhiteList([user], 4.8 * (10 ** 18));
+    await ico.addToWhiteList([user], web3.toWei(4.8));
   });
 
   /**
@@ -25,7 +26,7 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
       - Set time before ICO starting time
   */
   it("should reject purchase before ICO started", async () => {
-    ico.sendTransaction({from: user, value: 1 * (10 ** 18)}).should.be.rejectedWith('revert');
+    ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.rejectedWith('revert');
   });
 
   /**
@@ -34,14 +35,14 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
     - A valid Tier 1 day-1 allocation (1.5 ETH)
     - Set time after ICO starting time
   */
-  it("should fulfilled purchase after ICO started", async () => {
+  it("should fulfill purchase after ICO is started", async () => {
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(10) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 1.5 * (10 ** 18)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(1.5)}).should.be.fulfilled;
     let eth_after = await web3.eth.getBalance(wallet);
-    assert.equal(eth_after.minus(eth_before).toNumber(), (1.5 * (10 ** 18)));
+    assert.equal(eth_after.minus(eth_before).toNumber(), web3.toWei(1.5));
     let tokenBalance = await token.balanceOf(user);
-    assert.equal(tokenBalance.toNumber(), 14502 * (10 ** 18));
+    assert.equal(tokenBalance.toNumber(), web3.toWei(14502));
   });
 
   /**
@@ -52,7 +53,7 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
   */
   it("should reject purchase for the user that is not in whiteList", async () => {
     await increaseTime(duration.days(10) + duration.minutes(1));
-    await ico.sendTransaction({from: userNotInWhiteList, value: 1.5 * (10 ** 18)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: userNotInWhiteList, value: web3.toWei(1.5)}).should.be.rejectedWith('revert');
   });
 
   /**
@@ -63,7 +64,7 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
   */
   it("should reject purchase for the user that send eth exceed the limitation", async () => {
     await increaseTime(duration.days(10) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 4.81 * (10 ** 18)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(4.81)}).should.be.rejectedWith('revert');
   })
 
   /**
@@ -75,11 +76,11 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
   it("should fulfilled purchase after second day of ICO started with double purchase", async () => {
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(11) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 9.5 * (10 ** 18)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(9.5)}).should.be.fulfilled;
     let eth_after = await web3.eth.getBalance(wallet);
-    assert.equal(eth_after.minus(eth_before).toNumber(), (9.5 * (10 ** 18)));
+    assert.equal(eth_after.minus(eth_before).toNumber(), web3.toWei(9.5));
     let tokenBalance = await token.balanceOf(user);
-    assert.equal(tokenBalance.toNumber(), 91846 * (10 ** 18));
+    assert.equal(tokenBalance.toNumber(), web3.toWei(91846));
   });
 
   /**
@@ -90,7 +91,7 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
   */
   it("should rejected purchase for the user that send eth exceed the limitation for the second day", async () => {
     await increaseTime(duration.days(11) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 9.7 * (10 ** 18)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(9.7)}).should.be.rejectedWith('revert');
   })
 
   /**
@@ -102,11 +103,11 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
   it("should fulfilled purchase after third day of ICO started with big amount of ETH", async () => {
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(12) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 9.7 * (10 ** 18)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(9.7)}).should.be.fulfilled;
     let eth_after = await web3.eth.getBalance(wallet);
-    assert.equal(eth_after.minus(eth_before).toNumber(), (9.7 * (10 ** 18)));
+    assert.equal(eth_after.minus(eth_before).toNumber(), web3.toWei(9.7));
     let tokenBalance = await token.balanceOf(user);
-    assert.equal(tokenBalance.toNumber(), 93779.6 * (10 ** 18));
+    assert.equal(tokenBalance.toNumber(), web3.toWei(93779.6));
   });
 
   /**
@@ -117,34 +118,36 @@ contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWh
     - Set time after third day
   */
   it("should reject purchase after the thir day if ico has collected enough eth", async () => {
-    let weiCap = 100 * (10 ** 18);
+    let weiCap = web3.toWei(100);
     let ratePerWei = 9668;
-    let ico2 = await ICO.new(wallet,ratePerWei,latestTime()+duration.days(10), weiCap);
+    let ico2 = await ICO.new(wallet, ratePerWei, latestTime() + duration.days(10), weiCap);
 
-    await ico2.addToWhiteList([user], 4.8 * (10 ** 18));
+    await ico2.addToWhiteList([user], web3.toWei(4.8));
 
-    await ico2.addToWhiteList([superRichUser], 1000000 * (10 ** 18));//Supser user would be able to put the ICO contract has enough eth_after
+    await ico2.addToWhiteList([superRichUser], web3.toWei(1000000)); // Super user would be able to put the ICO contract has enough eth_after
     await increaseTime(duration.days(12) + duration.minutes(1));
-    await ico2.sendTransaction({from: superRichUser, value: 97 * (10 ** 18)}).should.be.fulfilled;
-    await ico2.sendTransaction({from: user, value: 4 * (10 ** 18)}).should.be.rejectedWith('revert');
+    await ico2.sendTransaction({from: superRichUser, value: web3.toWei(97)}).should.be.fulfilled;
+    await ico2.sendTransaction({from: user, value: web3.toWei(4)}).should.be.rejectedWith('revert');
+    await ico2.sendTransaction({from: user, value: web3.toWei(3)}).should.be.fulfilled;
   })
 
   it("should reject the second purchase within 24 hours", async () => {
     await increaseTime(duration.days(11) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 2 * (10 ** 18)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: 2 * (10 ** 18)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.rejectedWith('revert');
   })
 
   it("should not allow token to be able to transfer before close sale", async () => {
     await increaseTime(duration.days(11) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 2 * (10 ** 18)}).should.be.fulfilled;
-    await token.transfer(userNotInWhiteList, 10 * (10 ** 18), {from: user}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
+    await token.transfer(userNotInWhiteList, web3.toWei(10), {from: user}).should.be.rejectedWith('revert');
   })
+
   it("should allow token to be able to transfer after close sale and token activate", async () => {
     await increaseTime(duration.days(11) + duration.minutes(1));
-    await ico.sendTransaction({from: user, value: 2 * (10 ** 18)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
     await ico.closeSale();
     await token.activate();
-    await token.transfer(userNotInWhiteList, 10 * (10 ** 18), {from: user}).should.be.fulfilled;
+    await token.transfer(userNotInWhiteList, web3.toWei(10), {from: user}).should.be.fulfilled;
   })
 })

--- a/scenarios/icoPurchaseTest.js
+++ b/scenarios/icoPurchaseTest.js
@@ -7,7 +7,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
-contract('ICO contract ', function([owner, wallet, user, userNotInWhiteList, superRichUser, newOwner]) {
+contract('ICO contract -- buyTokens', function([owner, wallet, user, userNotInWhiteList, superRichUser, newOwner]) {
   let ico ;
   let token;
   beforeEach(async ()=>{

--- a/scenarios/preSaleTest.js
+++ b/scenarios/preSaleTest.js
@@ -7,28 +7,29 @@ require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
-  contract('ICO contract', function([tokenOwner, wallet, user, nonaddToWhiteListUser,otherUser,newOwner, advisor]) {
+  contract('ICO contract -- presale', function([tokenOwner, wallet, user, nonaddToWhiteListUser,otherUser,newOwner, advisor]) {
 
     let token;
     let ico;
 
-    beforeEach(async ()=>{
-      //let weiCap = 1000000 * (10 ** 18);//covert eth to wei
+    beforeEach(async () => {
       let weiCap = 10000 * (10 ** 18);
-      let ratePerWei = 9668; //convert to rate per wei
+      let ratePerWei = 9668; // convert to rate per wei
       ico = await ICO.new(wallet,ratePerWei,latestTime(), weiCap);
       token = OneledgerToken.at(await ico.token());
       await ico.addToWhiteList([user], 4.8 * (10 ** 18));
     });
+
     it('should not allow to buy new token when ICO contract is closed', async () => {
       await ico.closeSale(newOwner);
       await ico.sendTransaction({from: user, value: 4.8 * (10 ** 18)}).should.be.rejectedWith('revert');
       let balanceOf = await token.balanceOf(newOwner);
       assert.equal(balanceOf.toNumber(), 1000000000 * (10 ** 18))
     });
+
     it('should be able to allow deploy the vesting contract', async () => {
       let totalToken = 1933701 * (10**18);
       await OneledgerTokenVesting.new(advisor, latestTime() + duration.minutes(10),
-                                                duration.weeks(4), totalToken/12).should.be.fulfilled;
+                                      duration.weeks(4), totalToken/12).should.be.fulfilled;
     })
   })

--- a/scenarios/preSaleTest.js
+++ b/scenarios/preSaleTest.js
@@ -13,23 +13,23 @@ require('chai')
     let ico;
 
     beforeEach(async () => {
-      let weiCap = 10000 * (10 ** 18);
+      let weiCap = web3.toWei(10000);
       let ratePerWei = 9668; // convert to rate per wei
-      ico = await ICO.new(wallet,ratePerWei,latestTime(), weiCap);
+      ico = await ICO.new(wallet, ratePerWei, latestTime(), weiCap);
       token = OneledgerToken.at(await ico.token());
-      await ico.addToWhiteList([user], 4.8 * (10 ** 18));
+      await ico.addToWhiteList([user], web3.toWei(4.8));
     });
 
     it('should not allow to buy new token when ICO contract is closed', async () => {
       await ico.closeSale();
-      await ico.sendTransaction({from: user, value: 4.8 * (10 ** 18)}).should.be.rejectedWith('revert');
+      await ico.sendTransaction({from: user, value: web3.toWei(4.8)}).should.be.rejectedWith('revert');
       let balanceOf = await token.balanceOf(web3.eth.coinbase);
-      assert.equal(balanceOf.toNumber(), 1000000000 * (10 ** 18))
+      assert.equal(balanceOf.toNumber(), web3.toWei(1000000000))
     });
 
     it('should be able to allow deploy the vesting contract', async () => {
-      let totalToken = 1933701 * (10**18);
+      let totalToken = web3.toWei(1933701);
       await OneledgerTokenVesting.new(advisor, latestTime() + duration.minutes(10),
-                                      duration.weeks(4), totalToken/12).should.be.fulfilled;
+                                      duration.weeks(4), totalToken / 12).should.be.fulfilled;
     })
   })

--- a/scenarios/preSaleTest.js
+++ b/scenarios/preSaleTest.js
@@ -21,9 +21,9 @@ require('chai')
     });
 
     it('should not allow to buy new token when ICO contract is closed', async () => {
-      await ico.closeSale(newOwner);
+      await ico.closeSale();
       await ico.sendTransaction({from: user, value: 4.8 * (10 ** 18)}).should.be.rejectedWith('revert');
-      let balanceOf = await token.balanceOf(newOwner);
+      let balanceOf = await token.balanceOf(web3.eth.coinbase);
       assert.equal(balanceOf.toNumber(), 1000000000 * (10 ** 18))
     });
 

--- a/scenarios/vestingTest.js
+++ b/scenarios/vestingTest.js
@@ -2,7 +2,6 @@ const OneledgerToken = artifacts.require('OneledgerToken');
 const ICO = artifacts.require("ICO");
 const OneledgerTokenVesting = artifacts.require("OneledgerTokenVesting");
 const {increaseTime, latestTime, duration} = require('../test/timeIncrease')(web3);
-const {tokener,ether} = require('../test/tokener');
 const BigNumber = web3.BigNumber;
 require('chai')
   .use(require('chai-as-promised'))
@@ -16,9 +15,9 @@ require('chai')
 
     beforeEach(async ()=>{
 
-      let weiCap = ether(10000);
-      let ratePerWei = 9668; //convert to rate per wei
-      ico = await ICO.new(wallet,ratePerWei,latestTime(), weiCap);
+      let weiCap = web3.toWei(10000);
+      let ratePerWei = 9668; // convert to rate per wei
+      ico = await ICO.new(wallet, ratePerWei, latestTime(), weiCap);
       token = await OneledgerToken.at(await ico.token());
     });
 
@@ -28,14 +27,14 @@ require('chai')
       await ico.closeSale(newOwner);
       token.activate({from:newOwner});
       let totalToken = 1933701;
-      let vesting1 = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), tokener(totalToken/12));
-      let vesting2 = await OneledgerTokenVesting.new(advisor2, latestTime()+ duration.minutes(10),duration.weeks(4), tokener(totalToken/12));
-      await token.transfer(vesting1.address, tokener(1933701),{from:newOwner}).should.be.fulfilled;
-      await token.transfer(vesting2.address, tokener(1933701),{from:newOwner}).should.be.fulfilled;
+      let vesting1 = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), web3.toWei(totalToken/12));
+      let vesting2 = await OneledgerTokenVesting.new(advisor2, latestTime()+ duration.minutes(10),duration.weeks(4), web3.toWei(totalToken/12));
+      await token.transfer(vesting1.address, web3.toWei(1933701),{from:newOwner}).should.be.fulfilled;
+      await token.transfer(vesting2.address, web3.toWei(1933701),{from:newOwner}).should.be.fulfilled;
     });
     //Advisor token vesting release schedule, release after first month
     it('should release the token in first month', async () => {
-      let totalToken = tokener(1933701);
+      let totalToken = web3.toWei(1933701);
       let vesting = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), totalToken/12);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale(newOwner);
@@ -47,7 +46,7 @@ require('chai')
 
     //Advisor token vesting release schedule, release after two month
     it('should release the token in first month', async () => {
-      let totalToken = tokener(1933701);
+      let totalToken = web3.toWei(1933701);
       let vesting = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), totalToken/12);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale(newOwner);
@@ -59,8 +58,8 @@ require('chai')
 
     //Advisor token vesting release schedule, release after three month
     it('should release the token in first month', async () => {
-      let totalToken = tokener(1933701);
-      let vesting = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), totalToken/12);
+      let totalToken = web3.toWei(1933701);
+      let vesting = await OneledgerTokenVesting.new(advisor1, latestTime() + duration.minutes(10), duration.weeks(4), totalToken/12);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale(newOwner);
       await token.activate({from:newOwner});
@@ -77,7 +76,7 @@ require('chai')
         - A valid Beneficiary address for testing
     */
     it('should release the token in first month', async () => {
-      let totalToken = tokener(10000000);
+      let totalToken = web3.toWei(10000000);
       let starting = latestTime() + duration.weeks(24);
       let cycle = 12;
       let frequency = duration.weeks(4);

--- a/scenarios/vestingTest.js
+++ b/scenarios/vestingTest.js
@@ -47,19 +47,19 @@ require('chai')
     //Advisor token vesting release schedule, release after two month
     it('should release the token in first month', async () => {
       let totalToken = web3.toWei(1933701);
-      let vesting = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), totalToken/12);
+      let vesting = await OneledgerTokenVesting.new(advisor1, latestTime() + duration.minutes(10),duration.weeks(4), totalToken / 12);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale();
       await token.activate();
-      await increaseTime(duration.weeks(8)+duration.minutes(20));
+      await increaseTime(duration.weeks(8) + duration.minutes(20));
       await vesting.release(token.address);
-      assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/6);
+      assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken / 6);
     })
 
     //Advisor token vesting release schedule, release after three month
     it('should release the token in first month', async () => {
       let totalToken = web3.toWei(1933701);
-      let vesting = await OneledgerTokenVesting.new(advisor1, latestTime() + duration.minutes(10), duration.weeks(4), totalToken/12);
+      let vesting = await OneledgerTokenVesting.new(advisor1, latestTime() + duration.minutes(10), duration.weeks(4), totalToken / 12);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale();
       await token.activate();

--- a/scenarios/vestingTest.js
+++ b/scenarios/vestingTest.js
@@ -63,10 +63,11 @@ require('chai')
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale();
       await token.activate();
-      await increaseTime(duration.weeks(12)+duration.minutes(20));
+      await increaseTime(duration.weeks(12) + duration.minutes(20));
       await vesting.release(token.address);
       assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/4);
     })
+
     /**
       Deploy company reserve token vesting contract
         - 10000000 OLT to be vested
@@ -80,7 +81,7 @@ require('chai')
       let starting = latestTime() + duration.weeks(24);
       let cycle = 12;
       let frequency = duration.weeks(4);
-      let vesting = await OneledgerTokenVesting.new(company, starting,frequency, totalToken/cycle);
+      let vesting = await OneledgerTokenVesting.new(company, starting, frequency, totalToken / cycle);
       await ico.mintToken(vesting.address, totalToken).should.be.fulfilled;
     })
   })

--- a/scenarios/vestingTest.js
+++ b/scenarios/vestingTest.js
@@ -7,7 +7,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
-  contract('Vesting contract', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
+  contract('Vesting contract', function([owner, wallet, advisor1, advisor2, company]) {
 
     let token;
     let ico;
@@ -24,21 +24,21 @@ require('chai')
     //Deploy advisor token vesting contract
     //ICO mints tokens to one advisor token vesting contract
     it ('should be able to create and mint expected token before ico closed', async () => {
-      await ico.closeSale(newOwner);
-      token.activate({from:newOwner});
+      await ico.closeSale();
+      token.activate();
       let totalToken = 1933701;
       let vesting1 = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), web3.toWei(totalToken/12));
       let vesting2 = await OneledgerTokenVesting.new(advisor2, latestTime()+ duration.minutes(10),duration.weeks(4), web3.toWei(totalToken/12));
-      await token.transfer(vesting1.address, web3.toWei(1933701),{from:newOwner}).should.be.fulfilled;
-      await token.transfer(vesting2.address, web3.toWei(1933701),{from:newOwner}).should.be.fulfilled;
+      await token.transfer(vesting1.address, web3.toWei(1933701)).should.be.fulfilled;
+      await token.transfer(vesting2.address, web3.toWei(1933701)).should.be.fulfilled;
     });
     //Advisor token vesting release schedule, release after first month
     it('should release the token in first month', async () => {
       let totalToken = web3.toWei(1933701);
       let vesting = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), totalToken/12);
       await ico.mintToken(vesting.address, totalToken);
-      await ico.closeSale(newOwner);
-      await token.activate({from:newOwner});
+      await ico.closeSale();
+      await token.activate();
       await increaseTime(duration.weeks(4)+duration.minutes(20));
       await vesting.release(token.address);
       assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/12);
@@ -49,8 +49,8 @@ require('chai')
       let totalToken = web3.toWei(1933701);
       let vesting = await OneledgerTokenVesting.new(advisor1, latestTime()+ duration.minutes(10),duration.weeks(4), totalToken/12);
       await ico.mintToken(vesting.address, totalToken);
-      await ico.closeSale(newOwner);
-      await token.activate({from:newOwner});
+      await ico.closeSale();
+      await token.activate();
       await increaseTime(duration.weeks(8)+duration.minutes(20));
       await vesting.release(token.address);
       assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/6);
@@ -61,8 +61,8 @@ require('chai')
       let totalToken = web3.toWei(1933701);
       let vesting = await OneledgerTokenVesting.new(advisor1, latestTime() + duration.minutes(10), duration.weeks(4), totalToken/12);
       await ico.mintToken(vesting.address, totalToken);
-      await ico.closeSale(newOwner);
-      await token.activate({from:newOwner});
+      await ico.closeSale();
+      await token.activate();
       await increaseTime(duration.weeks(12)+duration.minutes(20));
       await vesting.release(token.address);
       assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/4);

--- a/scenarios/vestingTest.js
+++ b/scenarios/vestingTest.js
@@ -8,7 +8,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
-  contract('The vesting contract', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
+  contract('Vesting contract', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
 
     let token;
     let ico;

--- a/scenarios/vestingTokenQuarterlyTest.js
+++ b/scenarios/vestingTokenQuarterlyTest.js
@@ -7,7 +7,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
-  contract('Vesting contract -- quarterly release', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
+  contract('Vesting contract -- quarterly release', function([owner, wallet, advisor1, advisor2, company]) {
 
     let token;
     let ico;
@@ -26,8 +26,8 @@ require('chai')
       let frequency = duration.weeks(13);
       vesting = await OneledgerTokenVesting.new(advisor1, starting,frequency, totalToken/cycle);
       await ico.mintToken(vesting.address, totalToken);
-      await ico.closeSale(newOwner);
-      await token.activate({from:newOwner});
+      await ico.closeSale();
+      await token.activate();
     });
 
     it('should release the token in a year quaterly', async () => {

--- a/scenarios/vestingTokenQuarterlyTest.js
+++ b/scenarios/vestingTokenQuarterlyTest.js
@@ -8,7 +8,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
-  contract('The vesting contract', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
+  contract('Vesting contract -- quarterly release', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
 
     let token;
     let ico;

--- a/scenarios/vestingTokenQuarterlyTest.js
+++ b/scenarios/vestingTokenQuarterlyTest.js
@@ -24,7 +24,7 @@ require('chai')
       let starting = latestTime() + duration.minutes(10);
       let cycle = 4;
       let frequency = duration.weeks(13);
-      vesting = await OneledgerTokenVesting.new(advisor1, starting,frequency, totalToken/cycle);
+      vesting = await OneledgerTokenVesting.new(advisor1, starting, frequency, totalToken / cycle);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale();
       await token.activate();
@@ -33,13 +33,13 @@ require('chai')
     it('should release the token in a year quaterly', async () => {
       await increaseTime(duration.weeks(13) + duration.minutes(10));
       await vesting.release(token.address).should.be.fulfilled;
-      assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/4);
+      assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken / 4);
       await increaseTime(duration.weeks(13) + duration.minutes(10));
       await vesting.release(token.address).should.be.fulfilled;
-      assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken/2);
+      assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken / 2);
       await increaseTime(duration.weeks(13) + duration.minutes(10));
       await vesting.release(token.address).should.be.fulfilled;
-      assert.equal((await token.balanceOf(advisor1)).toNumber(), new BigNumber(totalToken).times(3).dividedBy(4).toNumber());
+      assert.equal((await token.balanceOf(advisor1)).toNumber(), web3.toBigNumber(totalToken).times(3).dividedBy(4).toNumber());
       await increaseTime(duration.weeks(13) + duration.minutes(10));
       await vesting.release(token.address).should.be.fulfilled;
       assert.equal((await token.balanceOf(advisor1)).toNumber(), totalToken);

--- a/scenarios/vestingTokenQuarterlyTest.js
+++ b/scenarios/vestingTokenQuarterlyTest.js
@@ -2,7 +2,6 @@ const OneledgerToken = artifacts.require('OneledgerToken');
 const ICO = artifacts.require("ICO");
 const OneledgerTokenVesting = artifacts.require("OneledgerTokenVesting");
 const {increaseTime, latestTime, duration} = require('../test/timeIncrease')(web3);
-const {tokener,ether} = require('../test/tokener');
 const BigNumber = web3.BigNumber;
 require('chai')
   .use(require('chai-as-promised'))
@@ -17,11 +16,11 @@ require('chai')
 
     beforeEach(async ()=>{
 
-      let weiCap = ether(10000);
+      let weiCap = web3.toWei(10000);
       let ratePerWei = 9668; //convert to rate per wei
       ico = await ICO.new(wallet,ratePerWei,latestTime(), weiCap);
       token = await OneledgerToken.at(await ico.token());
-      totalToken = tokener(12000000);
+      totalToken = web3.toWei(12000000);
       let starting = latestTime() + duration.minutes(10);
       let cycle = 4;
       let frequency = duration.weeks(13);

--- a/scenarios/vestingTokenToCompanyTest.js
+++ b/scenarios/vestingTokenToCompanyTest.js
@@ -8,7 +8,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bignumber')(BigNumber))
   .should();
-  contract('The vesting contract', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
+  contract('Vesting contract -- monthly release', function([owner, newOwner, wallet, advisor1, advisor2, company]) {
 
     let token;
     let ico;
@@ -25,7 +25,7 @@ require('chai')
       let starting = latestTime() + duration.weeks(20);//give 4 weeks space so that vesting can happen at exactly 24 weeks
       let cycle = 12;
       let frequency = duration.weeks(4);
-      vesting = await OneledgerTokenVesting.new(company, starting,frequency, totalToken/cycle);
+      vesting = await OneledgerTokenVesting.new(company, starting, frequency, totalToken/cycle);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale(newOwner);
       await token.activate({from:newOwner});
@@ -37,6 +37,7 @@ require('chai')
       await vesting.release(token.address).should.be.fulfilled;
       assert.equal((await token.balanceOf(company)).toNumber(), totalToken/12);
     })
+
     //Release starting from the first 7 months
     it('should release the token in first 7 month', async () => {
       await increaseTime(duration.weeks(24) + duration.minutes(10));
@@ -46,6 +47,7 @@ require('chai')
       await vesting.release(token.address).should.be.fulfilled;
       assert.equal((await token.balanceOf(company)).toNumber(), totalToken/6);
     })
+
     //Release starting from the first 9 months
     it('should release the token in first 7 month', async () => {
       await increaseTime(duration.weeks(24) + duration.minutes(10));

--- a/scenarios/vestingTokenToCompanyTest.js
+++ b/scenarios/vestingTokenToCompanyTest.js
@@ -2,7 +2,6 @@ const OneledgerToken = artifacts.require('OneledgerToken');
 const ICO = artifacts.require("ICO");
 const OneledgerTokenVesting = artifacts.require("OneledgerTokenVesting");
 const {increaseTime, latestTime, duration} = require('../test/timeIncrease')(web3);
-const {tokener,ether} = require('../test/tokener');
 const BigNumber = web3.BigNumber;
 require('chai')
   .use(require('chai-as-promised'))
@@ -15,17 +14,17 @@ require('chai')
     let vesting;
     let totalToken;
 
-    beforeEach(async ()=>{
+    beforeEach(async () => {
 
-      let weiCap = ether(10000);
-      let ratePerWei = 9668; //convert to rate per wei
-      ico = await ICO.new(wallet,ratePerWei,latestTime(), weiCap);
+      let weiCap = web3.toWei(10000);
+      let ratePerWei = 9668; // convert to rate per wei
+      ico = await ICO.new(wallet, ratePerWei, latestTime(), weiCap);
       token = await OneledgerToken.at(await ico.token());
-      totalToken = tokener(12000000);
-      let starting = latestTime() + duration.weeks(20);//give 4 weeks space so that vesting can happen at exactly 24 weeks
+      totalToken = web3.toWei(12000000);
+      let starting = latestTime() + duration.weeks(20); // give 4 weeks space so that vesting can happen at exactly 24 weeks
       let cycle = 12;
       let frequency = duration.weeks(4);
-      vesting = await OneledgerTokenVesting.new(company, starting, frequency, totalToken/cycle);
+      vesting = await OneledgerTokenVesting.new(company, starting, frequency, totalToken / cycle);
       await ico.mintToken(vesting.address, totalToken);
       await ico.closeSale(newOwner);
       await token.activate({from:newOwner});

--- a/scenarios/vestingTokenToCompanyTest.js
+++ b/scenarios/vestingTokenToCompanyTest.js
@@ -26,8 +26,8 @@ require('chai')
       let frequency = duration.weeks(4);
       vesting = await OneledgerTokenVesting.new(company, starting, frequency, totalToken / cycle);
       await ico.mintToken(vesting.address, totalToken);
-      await ico.closeSale(newOwner);
-      await token.activate({from:newOwner});
+      await ico.closeSale();
+      await token.activate();
     });
 
     //Release starting from the first 6 months

--- a/test/icoInitializeTest.js
+++ b/test/icoInitializeTest.js
@@ -1,7 +1,6 @@
 var OneledgerToken = artifacts.require('./OneledgerToken.sol');
 var ICO = artifacts.require("ICO");
 const {increaseTime, latestTime, duration} = require('./timeIncrease')(web3);
-const {tokener,ether} = require('./tokener');
 const BigNumber = web3.BigNumber;
 require('chai')
   .use(require('chai-as-promised'))
@@ -19,10 +18,10 @@ contract('ICO Initialize', function([tokenOwner, wallet, user, nonaddToWhiteList
   });
 
   it('should fail if wallet address is 0', async () => {
-    await ICO.new(0, 10, latestTime(),100000000000000).should.be.rejectedWith('revert');
+    await ICO.new(0, 10, latestTime(), 100000000000000).should.be.rejectedWith('revert');
   });
 
   it('should fail if weiCap is too huge', async () => {
-    await ICO.new(wallet, 10, latestTime(),ether(100000001)).should.be.rejectedWith('revert');
+    await ICO.new(wallet, 10, latestTime(), web3.toWei(100000001)).should.be.rejectedWith('revert');
   });
 })

--- a/test/icoInitializeTest.js
+++ b/test/icoInitializeTest.js
@@ -8,13 +8,9 @@ require('chai')
   .should();
 
 contract('ICO Initialize', function([tokenOwner, wallet, user, nonaddToWhiteListUser]) {
-  let ico  = null;
-  beforeEach(async ()=>{
-
-  });
 
   it('should fail if rate is negative', async () => {
-    await ICO.new(wallet, 0,latestTime(), 100000000000000).should.be.rejectedWith('revert');
+    await ICO.new(wallet, 0, latestTime(), 100000000000000).should.be.rejectedWith('revert');
   });
 
   it('should fail if wallet address is 0', async () => {
@@ -24,4 +20,5 @@ contract('ICO Initialize', function([tokenOwner, wallet, user, nonaddToWhiteList
   it('should fail if weiCap is too huge', async () => {
     await ICO.new(wallet, 10, latestTime(), web3.toWei(100000001)).should.be.rejectedWith('revert');
   });
+
 })

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -2,7 +2,6 @@ var OneledgerToken = artifacts.require('OneledgerToken.sol');
 var OneledgerTokenVesting = artifacts.require('./OneledgerTokenVesting.sol');
 var ICO = artifacts.require("ICO");
 const {increaseTime, latestTime, duration} = require('./timeIncrease')(web3);
-const {tokener,ether} = require('./tokener');
 const BigNumber = web3.BigNumber;
 require('chai')
   .use(require('chai-as-promised'))
@@ -17,127 +16,127 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser,otherUser,newOwner
   let token;
 
   beforeEach(async ()=>{
-    ico = await ICO.new(wallet,10,latestTime() + duration.days(1), ether(10000));
-    token =await OneledgerToken.at(await ico.token());
+    ico = await ICO.new(wallet,10,latestTime() + duration.days(1), web3.toWei(10000));
+    token = await OneledgerToken.at(await ico.token());
   });
 
   it('should be able to mint new token for vesting contract', async () => {
-    let vesting = await OneledgerTokenVesting.new(beneficiary, latestTime(),duration.weeks(4), tokener(10));
-    await ico.mintToken(vesting.address, tokener(120)).should.be.fulfilled;
+    let vesting = await OneledgerTokenVesting.new(beneficiary, latestTime(),duration.weeks(4), web3.toWei(10));
+    await ico.mintToken(vesting.address, web3.toWei(120)).should.be.fulfilled;
   })
 
   it('should not be able to buy token, since user is not in the addToWhiteList', async () => {
     let eth_before = await web3.eth.getBalance(wallet);
     let eth_after = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(1) + duration.seconds(1));
-    await ico.sendTransaction({from: user, value: ether(4)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(4)}).should.be.rejectedWith('revert');
     assert.equal(eth_after.minus(eth_before), 0);
   });
   it('should be able to buy token when the user was added in the addToWhiteList', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(1));
     let eth_before = await web3.eth.getBalance(wallet);
-    await ico.sendTransaction({from: user, value: ether(1)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: ether(1)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.rejectedWith('revert');
     let eth_after = await web3.eth.getBalance(wallet);
-    assert.equal(eth_after.minus(eth_before), ether(1));
+    assert.equal(eth_after.minus(eth_before), web3.toWei(1));
   });
   it('should be able to buy token when the user was added in the addToWhiteList, the second day buy double', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(1) + duration.seconds(1));
-    await ico.sendTransaction({from: user, value: ether(1)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: ether(1)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.rejectedWith('revert');
     await increaseTime(duration.days(1)+duration.seconds(1));
-    await ico.sendTransaction({from: user, value: ether(3)}).should.be.rejectedWith('revert');
-    await ico.sendTransaction({from: user, value: ether(2)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: ether(2)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(3)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.rejectedWith('revert');
     let eth_after = await web3.eth.getBalance(wallet);
-    assert.equal(eth_after.minus(eth_before), ether(3));
+    assert.equal(eth_after.minus(eth_before), web3.toWei(3));
   });
   it('should be able to buy token when the user was added in the addToWhiteList, the second day buy double, the third day free for all', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(1) + duration.seconds(1));
-    await ico.sendTransaction({from: user, value: ether(0.1)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: ether(0.1)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.rejectedWith('revert');
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(0.2)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: ether(0.2)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(0.2)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(0.2)}).should.be.rejectedWith('revert');
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(0.4)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: ether(0.3)}).should.be.rejectedWith('revert');//one day one purchase
+    await ico.sendTransaction({from: user, value: web3.toWei(0.4)}).should.be.fulfilled;
+    await ico.sendTransaction({from: user, value: web3.toWei(0.3)}).should.be.rejectedWith('revert');//one day one purchase
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(0.1)}).should.be.fulfilled;
-    await ico.sendTransaction({from: nonaddToWhiteListUser, value: ether(0.2)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.fulfilled;
+    await ico.sendTransaction({from: nonaddToWhiteListUser, value: web3.toWei(0.2)}).should.be.rejectedWith('revert');
 
     let eth_after = await web3.eth.getBalance(wallet);
-    assert.equal(eth_after.minus(eth_before).toNumber(), ether(0.8));
+    assert.equal(eth_after.minus(eth_before).toNumber(), web3.toWei(0.8));
   });
   it('should not allow to buy new token when ICO contract is closed', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     await ico.closeSale(newOwner);
-    await ico.sendTransaction({from: user, value: ether(0.5)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(0.5)}).should.be.rejectedWith('revert');
   });
   it('should not allow purchase when trying to buy too much token for the first day', async () => {
-    await ico.addToWhiteList([user],ether(1));
-    await ico.sendTransaction({from: user, value: ether(2)}).should.be.rejectedWith('revert');
+    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.rejectedWith('revert');
   });
   it('should not allow purchase when trying to buy too much token for the second day', async () => {
-    await ico.addToWhiteList([user],ether(1));;
+    await ico.addToWhiteList([user],web3.toWei(1));;
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(2.1)}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(2.1)}).should.be.rejectedWith('revert');
   });
   it('should reject any purchase if starting date is later than purchase date', async()=>{
-    let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),ether(10));
-    await ico2.sendTransaction({from: user, value: ether(10)}).should.be.rejectedWith('revert');
+    let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),web3.toWei(10));
+    await ico2.sendTransaction({from: user, value: web3.toWei(10)}).should.be.rejectedWith('revert');
   });
   it('should allow purchase if starting date is ealier than purchase date', async()=>{
-    let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),ether(1));
-    await ico2.addToWhiteList([user],ether(0.5));
+    let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),web3.toWei(1));
+    await ico2.addToWhiteList([user],web3.toWei(0.5));
     await increaseTime(duration.days(7) + duration.seconds(10));
-    await ico2.sendTransaction({from: user, value: ether(0.4)}).should.be.fulfilled;
+    await ico2.sendTransaction({from: user, value: web3.toWei(0.4)}).should.be.fulfilled;
   });
   it('should not allowed user to transfer token during ICO sales period', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(1)}).should.be.fulfilled;
-    await token.transfer(otherUser, tokener(1), {from: user}).should.be.rejectedWith('revert');
+    await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
+    await token.transfer(otherUser, web3.toWei(1), {from: user}).should.be.rejectedWith('revert');
   });
   it('should allowed user to transfer token after ICO sales period', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(1)});
+    await ico.sendTransaction({from: user, value: web3.toWei(1)});
     await ico.closeSale(newOwner);
     await token.activate({from:newOwner});
-    await token.transfer(otherUser, tokener(10), {from: user}).should.be.fulfilled;
+    await token.transfer(otherUser, web3.toWei(10), {from: user}).should.be.fulfilled;
   });
   it('should transfer the left balance to the new owner after saleClosed', async () => {
-    await ico.addToWhiteList([user],ether(1));
+    await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(1)});
+    await ico.sendTransaction({from: user, value: web3.toWei(1)});
     await ico.closeSale(newOwner);
     let result = await token.balanceOf(newOwner);
-    assert.equal(result.toNumber(), new BigNumber(tokener(1000000000)).sub(tokener(10)).toNumber());
+    assert.equal(result.toNumber(), new BigNumber(web3.toWei(1000000000)).sub(web3.toWei(10)).toNumber());
   });
   it('should have total token supply equal to weiCap * rate before sale close' ,async () => {
-    await ico.addToWhiteList([user],ether(3));
+    await ico.addToWhiteList([user],web3.toWei(3));
     await increaseTime(duration.days(1) + duration.seconds(10));
-    await ico.sendTransaction({from: user, value: ether(3)});
+    await ico.sendTransaction({from: user, value: web3.toWei(3)});
     let result = await token.totalSupply();
-    assert.equal(result.toNumber(), tokener(30));
+    assert.equal(result.toNumber(), web3.toWei(30));
   });
   it('should have reach total token supply after sale close' ,async () => {
     await ico.closeSale(newOwner);
     let result = await token.totalSupply();
-    assert.equal(result.toNumber(), tokener(1000000000));
+    assert.equal(result.toNumber(), web3.toWei(1000000000));
   });
   it('should reject if all weiRased is exceed the weiCap', async () => {
-    let ico2 = await ICO.new(wallet,10,latestTime(), ether(10));
+    let ico2 = await ICO.new(wallet,10,latestTime(), web3.toWei(10));
     await increaseTime(duration.days(4) + duration.seconds(10));
-    await ico2.addToWhiteList([user],ether(8));
-    await ico2.addToWhiteList([otherUser],ether(8));
-    await ico2.sendTransaction({from: otherUser, value: ether(8)}).should.be.fulfilled;
-    await ico2.sendTransaction({from: user, value: ether(8)}).should.be.rejectedWith('revert');
+    await ico2.addToWhiteList([user],web3.toWei(8));
+    await ico2.addToWhiteList([otherUser],web3.toWei(8));
+    await ico2.sendTransaction({from: otherUser, value: web3.toWei(8)}).should.be.fulfilled;
+    await ico2.sendTransaction({from: user, value: web3.toWei(8)}).should.be.rejectedWith('revert');
   })
 })

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -8,7 +8,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should();
 
-contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwner, beneficiary]) {
+contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, beneficiary]) {
 
   let ico;
   let token;
@@ -87,7 +87,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
 
   it('should not allow to buy new token when ICO contract is closed', async () => {
     await ico.addToWhiteList([user], web3.toWei(1));
-    await ico.closeSale(newOwner);
+    await ico.closeSale();
     await ico.sendTransaction({from: user, value: web3.toWei(0.5)}).should.be.rejectedWith('revert');
   });
 
@@ -103,7 +103,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
   });
 
   it('should reject any purchase if starting date is later than purchase date', async()=>{
-    let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),web3.toWei(10));
+    let ico2 = await ICO.new(wallet, 10, latestTime() + duration.days(7), web3.toWei(10));
     await ico2.sendTransaction({from: user, value: web3.toWei(10)}).should.be.rejectedWith('revert');
   });
 
@@ -125,17 +125,17 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(1)});
-    await ico.closeSale(newOwner);
-    await token.activate({from:newOwner});
+    await ico.closeSale();
+    await token.activate();
     await token.transfer(otherUser, web3.toWei(10), {from: user}).should.be.fulfilled;
   });
 
-  it('should transfer the left balance to the new owner after saleClosed', async () => {
+  it('should transfer the remaining balance to the new owner after saleClosed', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(1)});
-    await ico.closeSale(newOwner);
-    let result = await token.balanceOf(newOwner);
+    await ico.closeSale();
+    let result = await token.balanceOf(web3.eth.coinbase);
     assert.equal(result.toNumber(), new BigNumber(web3.toWei(1000000000)).sub(web3.toWei(10)).toNumber());
   });
 
@@ -148,7 +148,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
   });
 
   it('should have reach total token supply after sale close' ,async () => {
-    await ico.closeSale(newOwner);
+    await ico.closeSale();
     let result = await token.totalSupply();
     assert.equal(result.toNumber(), web3.toWei(1000000000));
   });

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -63,7 +63,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
   });
 
   it('should be able to buy token when the user was added in the addToWhiteList, the second day buy double, the third day free for all', async () => {
-    await ico.addToWhiteList([user], web3.toWei(1));
+    await ico.addToWhiteList([user, otherUser], web3.toWei(1));
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(1) + duration.seconds(1));
     await ico.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.fulfilled;

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -37,25 +37,31 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     await increaseTime(duration.days(1) + duration.seconds(1));
     let eth_before = await web3.eth.getBalance(wallet);
     await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
-    userBalance = await token.balanceOf(user);
+    let userBalance = await token.balanceOf(user);
     userBalance.should.be.bignumber.equal(rate * web3.toWei(1));
     await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.rejectedWith('revert');
     let eth_after = await web3.eth.getBalance(wallet);
     assert.equal(eth_after.minus(eth_before), web3.toWei(1));
   });
+
   it('should be able to buy token when the user was added in the addToWhiteList, the second day buy double', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(1) + duration.seconds(1));
     await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
+    let userBalance = await token.balanceOf(user);
+    userBalance.should.be.bignumber.equal(rate * web3.toWei(1));
     await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.rejectedWith('revert');
     await increaseTime(duration.days(1) + duration.seconds(1));
     await ico.sendTransaction({from: user, value: web3.toWei(3)}).should.be.rejectedWith('revert');
     await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
+    userBalance = await token.balanceOf(user);
+    userBalance.should.be.bignumber.equal(rate * web3.toWei(3));
     await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.rejectedWith('revert');
     let eth_after = await web3.eth.getBalance(wallet);
     assert.equal(eth_after.minus(eth_before), web3.toWei(3));
   });
+
   it('should be able to buy token when the user was added in the addToWhiteList, the second day buy double, the third day free for all', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     let eth_before = await web3.eth.getBalance(wallet);
@@ -75,6 +81,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     let eth_after = await web3.eth.getBalance(wallet);
     assert.equal(eth_after.minus(eth_before).toNumber(), web3.toWei(0.8));
   });
+
   it('should not allow to buy new token when ICO contract is closed', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     await ico.closeSale(newOwner);

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -90,31 +90,37 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     await ico.closeSale(newOwner);
     await ico.sendTransaction({from: user, value: web3.toWei(0.5)}).should.be.rejectedWith('revert');
   });
+
   it('should not allow purchase when trying to buy too much token for the first day', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.rejectedWith('revert');
   });
+
   it('should not allow purchase when trying to buy too much token for the second day', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));;
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(2.1)}).should.be.rejectedWith('revert');
   });
+
   it('should reject any purchase if starting date is later than purchase date', async()=>{
     let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),web3.toWei(10));
     await ico2.sendTransaction({from: user, value: web3.toWei(10)}).should.be.rejectedWith('revert');
   });
+
   it('should allow purchase if starting date is ealier than purchase date', async()=>{
     let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),web3.toWei(1));
     await ico2.addToWhiteList([user],web3.toWei(0.5));
     await increaseTime(duration.days(7) + duration.seconds(10));
     await ico2.sendTransaction({from: user, value: web3.toWei(0.4)}).should.be.fulfilled;
   });
+
   it('should not allowed user to transfer token during ICO sales period', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
     await token.transfer(otherUser, web3.toWei(1), {from: user}).should.be.rejectedWith('revert');
   });
+
   it('should allowed user to transfer token after ICO sales period', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
@@ -123,6 +129,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     await token.activate({from:newOwner});
     await token.transfer(otherUser, web3.toWei(10), {from: user}).should.be.fulfilled;
   });
+
   it('should transfer the left balance to the new owner after saleClosed', async () => {
     await ico.addToWhiteList([user],web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
@@ -131,6 +138,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     let result = await token.balanceOf(newOwner);
     assert.equal(result.toNumber(), new BigNumber(web3.toWei(1000000000)).sub(web3.toWei(10)).toNumber());
   });
+
   it('should have total token supply equal to weiCap * rate before sale close' ,async () => {
     await ico.addToWhiteList([user],web3.toWei(3));
     await increaseTime(duration.days(1) + duration.seconds(10));
@@ -138,11 +146,13 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     let result = await token.totalSupply();
     assert.equal(result.toNumber(), web3.toWei(30));
   });
+
   it('should have reach total token supply after sale close' ,async () => {
     await ico.closeSale(newOwner);
     let result = await token.totalSupply();
     assert.equal(result.toNumber(), web3.toWei(1000000000));
   });
+
   it('should reject if all weiRased is exceed the weiCap', async () => {
     let ico2 = await ICO.new(wallet,10,latestTime(), web3.toWei(10));
     await increaseTime(duration.days(4) + duration.seconds(10));

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -139,7 +139,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
     assert.equal(result.toNumber(), new BigNumber(web3.toWei(1000000000)).sub(web3.toWei(10)).toNumber());
   });
 
-  it('should have total token supply equal to weiCap * rate before sale close' ,async () => {
+  it('should have total token supply equal to weiRaised * rate before sale close' ,async () => {
     await ico.addToWhiteList([user], web3.toWei(3));
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(3)});
@@ -153,12 +153,15 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
     assert.equal(result.toNumber(), web3.toWei(1000000000));
   });
 
-  it('should reject if all weiRased is exceed the weiCap', async () => {
+  it('should reject if all weiRaised exceeds the weiCap', async () => {
     let ico2 = await ICO.new(wallet, 10, latestTime(), web3.toWei(10));
     await increaseTime(duration.days(4) + duration.seconds(10));
-    await ico2.addToWhiteList([user],web3.toWei(8));
-    await ico2.addToWhiteList([otherUser],web3.toWei(8));
+    await ico2.addToWhiteList([user], web3.toWei(8));
+    await ico2.addToWhiteList([otherUser], web3.toWei(8));
     await ico2.sendTransaction({from: otherUser, value: web3.toWei(8)}).should.be.fulfilled;
     await ico2.sendTransaction({from: user, value: web3.toWei(8)}).should.be.rejectedWith('revert');
+    await ico2.sendTransaction({from: user, value: web3.toWei(3)}).should.be.rejectedWith('revert');
+    await ico2.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
+    await ico2.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.rejectedWith('revert');
   })
 })

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -92,12 +92,12 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
   });
 
   it('should not allow purchase when trying to buy too much token for the first day', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.addToWhiteList([user], web3.toWei(1));
     await ico.sendTransaction({from: user, value: web3.toWei(2)}).should.be.rejectedWith('revert');
   });
 
   it('should not allow purchase when trying to buy too much token for the second day', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));;
+    await ico.addToWhiteList([user], web3.toWei(1));;
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(2.1)}).should.be.rejectedWith('revert');
   });
@@ -107,22 +107,22 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
     await ico2.sendTransaction({from: user, value: web3.toWei(10)}).should.be.rejectedWith('revert');
   });
 
-  it('should allow purchase if starting date is ealier than purchase date', async()=>{
-    let ico2 = await ICO.new(wallet,10,latestTime()+ duration.days(7),web3.toWei(1));
-    await ico2.addToWhiteList([user],web3.toWei(0.5));
+  it('should allow purchase if starting date is earlier than purchase date', async()=>{
+    let ico2 = await ICO.new(wallet, 10, latestTime() + duration.days(7), web3.toWei(1));
+    await ico2.addToWhiteList([user], web3.toWei(0.5));
     await increaseTime(duration.days(7) + duration.seconds(10));
     await ico2.sendTransaction({from: user, value: web3.toWei(0.4)}).should.be.fulfilled;
   });
 
   it('should not allowed user to transfer token during ICO sales period', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.addToWhiteList([user], web3.toWei(1));
     increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(1)}).should.be.fulfilled;
     await token.transfer(otherUser, web3.toWei(1), {from: user}).should.be.rejectedWith('revert');
   });
 
   it('should allowed user to transfer token after ICO sales period', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.addToWhiteList([user], web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(1)});
     await ico.closeSale();
@@ -131,7 +131,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
   });
 
   it('should transfer the remaining balance to the new owner after saleClosed', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.addToWhiteList([user], web3.toWei(1));
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(1)});
     await ico.closeSale();
@@ -140,7 +140,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
   });
 
   it('should have total token supply equal to weiCap * rate before sale close' ,async () => {
-    await ico.addToWhiteList([user],web3.toWei(3));
+    await ico.addToWhiteList([user], web3.toWei(3));
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(3)});
     let result = await token.totalSupply();
@@ -154,7 +154,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
   });
 
   it('should reject if all weiRased is exceed the weiCap', async () => {
-    let ico2 = await ICO.new(wallet,10,latestTime(), web3.toWei(10));
+    let ico2 = await ICO.new(wallet, 10, latestTime(), web3.toWei(10));
     await increaseTime(duration.days(4) + duration.seconds(10));
     await ico2.addToWhiteList([user],web3.toWei(8));
     await ico2.addToWhiteList([otherUser],web3.toWei(8));

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -63,7 +63,7 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
   });
 
   it('should be able to buy token when the user was added in the addToWhiteList, the second day buy double, the third day free for all', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.addToWhiteList([user], web3.toWei(1));
     let eth_before = await web3.eth.getBalance(wallet);
     await increaseTime(duration.days(1) + duration.seconds(1));
     await ico.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.fulfilled;
@@ -73,17 +73,20 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, newOwn
     await ico.sendTransaction({from: user, value: web3.toWei(0.2)}).should.be.rejectedWith('revert');
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(0.4)}).should.be.fulfilled;
-    await ico.sendTransaction({from: user, value: web3.toWei(0.3)}).should.be.rejectedWith('revert');//one day one purchase
+    await ico.sendTransaction({from: user, value: web3.toWei(0.3)}).should.be.rejectedWith('revert'); // one day one purchase
     await increaseTime(duration.days(1) + duration.seconds(10));
     await ico.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.fulfilled;
     await ico.sendTransaction({from: nonaddToWhiteListUser, value: web3.toWei(0.2)}).should.be.rejectedWith('revert');
+
+    let userBalance = await token.balanceOf(user);
+    userBalance.should.be.bignumber.equal(rate * web3.toWei(0.8));
 
     let eth_after = await web3.eth.getBalance(wallet);
     assert.equal(eth_after.minus(eth_before).toNumber(), web3.toWei(0.8));
   });
 
   it('should not allow to buy new token when ICO contract is closed', async () => {
-    await ico.addToWhiteList([user],web3.toWei(1));
+    await ico.addToWhiteList([user], web3.toWei(1));
     await ico.closeSale(newOwner);
     await ico.sendTransaction({from: user, value: web3.toWei(0.5)}).should.be.rejectedWith('revert');
   });

--- a/test/icoTest.js
+++ b/test/icoTest.js
@@ -163,5 +163,5 @@ contract('ICO', function([wallet, user, nonaddToWhiteListUser, otherUser, benefi
     await ico2.sendTransaction({from: user, value: web3.toWei(3)}).should.be.rejectedWith('revert');
     await ico2.sendTransaction({from: user, value: web3.toWei(2)}).should.be.fulfilled;
     await ico2.sendTransaction({from: user, value: web3.toWei(0.1)}).should.be.rejectedWith('revert');
-  })
+  });
 })

--- a/test/tokenVestTest.js
+++ b/test/tokenVestTest.js
@@ -25,21 +25,24 @@ contract('OneledgerToken Vesting', function([owner,vestingOwner, beneficiary]){
   it('should not release token before the starting date',async ()=>{
     await vesting.release(token.address).should.be.rejectedWith('revert');
   });
+
   it('should only release once after the starting date and before the next release date', async () => {
     await increaseTime(duration.weeks(2) + duration.weeks(4) + duration.days(2));
     await vesting.release(token.address).should.be.fulfilled;
     await vesting.release(token.address).should.be.rejectedWith('revert');
     assert.equal( await token.balanceOf(beneficiary), 10000);
   });
+
   it('should only release twice after the starting date and before the next release date', async () => {
     await increaseTime(duration.weeks(2) + duration.weeks(4) * 2 + duration.days(2));
     await vesting.release(token.address).should.be.fulfilled;
     await vesting.release(token.address).should.be.rejectedWith('revert');
     assert.equal( await token.balanceOf(beneficiary), 20000);
   });
+
   it('should release the available balance if available balance is smaller than token ready to release', async () => {
     await increaseTime(duration.weeks(2) + duration.weeks(4) * 5 + duration.days(2));
     await vesting.release(token.address).should.be.fulfilled;
-    assert.equal( await token.balanceOf(beneficiary), 10000 * 4 + 2000);
+    assert.equal(await token.balanceOf(beneficiary), 10000 * 4 + 2000);
   })
 })

--- a/test/tokener.js
+++ b/test/tokener.js
@@ -1,5 +1,0 @@
-const tokener = (number)=>number * (10 ** 18);
-const ether = (number)=>number * (10 ** 18);
-module.exports = {
-  tokener,ether
-}

--- a/truffle.js
+++ b/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     ganache: {
       host: "localhost",
-      port: 7545,
+      port: 8546,
       network_id: "*" // Match any network id
     }
   }


### PR DESCRIPTION
## Changes

### Important changes

- simplified `OneLedgerTokenVesting.sol`
    + There is no reason for this contract to be `Ownable`, right? I've removed this inheritance.
- removed `newOwner` parameter from `closeSale` function which might end in disaster if the wrong value is passed. It is much safer to simply revert ownership to the owner of the `ICO` contract.
- removed needless `isInWhitelist` bool from `WhitelistRecord` struct
    + checking for non-zero `offeredWei` value to see if an address is whitelisted
- removed needless token contract constructor
- upgraded `truffle` to lastest version
   + this necessitates an update to the latest `solc` version as well, 0.4.23

### Minor changes

- created script to easily run scenario tests
   + created unique titles for each of the scenario test contracts
- changed ungrammatical modifier name `isActived` to `activated`
- removed needless file `tokener.js` and replaced `tokener` and `ether` functions with the more standard `web3.toWei`
- changed ICO private variables to public since they posed no security risk and might be useful to saleParticipants
- added sale participant token balance tests in `icoTest.js`
- Reverted Stephen's change to the ganache port (7545 -> 8456) which broke my ganache testing script
- changed event name in `TokenVesting` from `VestingReleased` to `Released` which is standard and more comprehensible

## Comments

- Introducing additional contract state in `OneledgerTokenVesting.sol` by using the `elapsedPeriods` variable is suboptimal.
     + issues can arise if `tokensReadyToRelease >= availableBalance` ever evaluates to true. If an investor's token vesting contract isn't supplied with the proper amount of tokens up front, an investor may have to wait longer than intended to release all of his tokens.
     + Make sure you send the right amount of tokens to each of these contracts after they're initialized!
- Make sure you don't want to set an endTime for the sale. Knowing that the sale must eventually end might incentivize sale participants to buy earlier rather than later.

### Notes on testing

- Much of the testing style is sloppy. For example, in `icoTest.js`, those test blocks which contain the deployment of a second ico contract called `ico2` should be in a separate test suite that does not contain a `beforeEach` that deploys an ico contract. This would greatly improve the readability of the tests.
- `scenarios/vestingTest.js`
     + Rounding errors are implicit in all the token vesting code. 10000000 is not divisible by 12... Why do you try to pass `web3.toWei(10000000) / 12` into the token vesting contract as the tokensReleasedPerPeriod? What if the remainder is 4 attotokens--do you want the investor to have to wait a month to retrieve his final 4 attotokens? That sounds like horrible user experience. You should round up your `tokensReleasedPerPeriod` to make sure this never happens in the real world. Please be very careful about picking interval vesting amounts and eliminate rounding errors from the tests!
              * this is not a problem in files like `vestingTokenQuarterlyTest.js` since `totalToken = web3.toWei(12000000)` is divisible by 4. I assume this won't always be the case so, again, be very careful.
      + There are numerous tests labelled "should release the token in first month" -- this is not very helpful and is often inaccurate. Please choose more descriptive test names to help people review your code.
- There are too many test files. Tests like the ones in `scenarios/deployICOTest.js` seem unnecessary since they can be executed as part of the `beforeEach` of other test files.
- `scenarios/preSaleTest.js` has nothing to do with presale functionality. Remove it or give it a better name.
- a lot of calls to `.toNumber()` could be avoided by using `.should.be.bignumber.equal`; this is safer because it avoids rounding errors.